### PR TITLE
APK location error fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 deploy:
   - provider: releases
     api_key: "072a767db621bbc5b85578c13b7195879092b8d0"
-    file: "th-player/platforms/android/build/outputs/apk/th-player.apk"
+    file: "th-player/platforms/android/build/outputs/apk/debug/th-player.apk"
     skip_cleanup: true
     on:
       tags: true

--- a/th-player/hooks/afterBuild_apkRename.js
+++ b/th-player/hooks/afterBuild_apkRename.js
@@ -8,7 +8,7 @@ module.exports = function (ctx) {
         deferral = ctx.requireCordovaModule('q').defer();
 
     var platformRoot = path.join(ctx.opts.projectRoot, 'platforms/android');
-    var apkFileLocation = path.join(platformRoot, 'build/outputs/apk/');
+    var apkFileLocation = path.join(platformRoot, 'build/outputs/apk/debug/');
     var oldApk = "android-debug.apk";
     var newApk = "th-player.apk";
 


### PR DESCRIPTION
Due to some unknown reason the generated apk was contained in a different folder. I updated the configuration for Travis deployment and Cordova's hook used for renaming the file.

The PR is going to close the #47 issue.